### PR TITLE
Fixed typo in devcontainer-template.json

### DIFF
--- a/src/python3-poetry-pyenv/devcontainer-template.json
+++ b/src/python3-poetry-pyenv/devcontainer-template.json
@@ -25,7 +25,7 @@
             "description": "Select the os to install",
             "proposals":[
                 "debian",
-                "bulleye",
+                "bullseye",
                 "buster",
                 "jammy",
                 "focal",


### PR DESCRIPTION
"bulleye" instead of "bullseye" led to an error at build time when choosing this distro.